### PR TITLE
Extend the list of stop words

### DIFF
--- a/blogs/utils.py
+++ b/blogs/utils.py
@@ -6,7 +6,11 @@ from nltk.corpus import stopwords #library used to filter out common english wor
 def top_word_counts(text):
 	stoplist = stopwords.words('english')
 	stoplist.extend(["said", "gutenberg", "could", "would", "shall", "unto", "thou", "thy", "ye", "thee",])
-	# stoplist.extend(list(range(0, 2000)))
+	# Added the mechanism to extend the list to include integers between 0 and 1999
+	extendinteger = list(range(0, 2000))
+	# Using map() it will convert the given type with one by iterations
+	# of the array and convert to the corresponding type
+	stoplist.extend(list(map(str,extendinteger)))
 	clean = []
 	for word in re.split(r"\W+", text):
 		if word not in stoplist:


### PR DESCRIPTION
- [x] **Extend the list of stop words**

Extend the list of stop words by including the mechanism to add integers of type  string between range of 0 - 2000.

We want to include a range of integers but in type of string append to it. We can do it manually using loops but the will look like messy and we don't want to do that mess, then we will use list(range()), extend and map functions as

Let say we have an array of string:

`stopwords = [ 'apple', 'ball', 'cat', 'egg' ]`

Or we can also generate an array `temp = [ 1, 2, 3, 4, 5 ]` by using list(range()) functions:

`temp = list(range(1,6))`

Now for converting it to an array of strings ? and appending to the stopwords list by extend and map functions:

`stopwords.extend( list( map( str, temp ) ) )`

How it happens ? the map functions takes a type and an array as an input and returns a list of the given type by converting every single element to the corresponding type. And the extend keywords will append the returned list by map function which a list of string to stopwords list. Now stopword list become as:

`stopwords = [ 'apple', 'ball', 'cat', 'egg', '1' , '2' , '3' , '4' , '5' ]`

